### PR TITLE
Removed the `CheckMemoryLeak` class from production code

### DIFF
--- a/JANGAN/CheckMemoryLeak/__init__.py
+++ b/JANGAN/CheckMemoryLeak/__init__.py
@@ -1,7 +1,20 @@
+from ProjectTools import AutoPackageInstaller as ap
+
+ap.CheckAndInstall("tracemalloc")
+
 import tracemalloc
 import time
 import os
 from os import path, write
+
+# A little how-to-use guide:
+## 1. Create an instance of this class somewhere
+## 2. Call the ConfigurePath(...) method, to setup the paths for log files
+## 3. Call the StartChecker(...) method when you are ready to start tracing
+## 4. Call the SaveKey(...) method before taking snapshots, so that it is possible to save snapshots to a certain key
+## 5. Call the SaveSnapshot(...) method when you wanna take a memory snapshot to a certain key
+## 6. Call the WriteToFile(...) sometimes, when you want to save the log file
+## 7. Finally you can call the CompareSnapshots(...) method, to get a comparison for all the saved snapshots
 
 class CheckMemoryLeak():
     TraceMallocPath = ""
@@ -18,18 +31,21 @@ class CheckMemoryLeak():
             os.makedirs(self.TracemallocPath)
 
         named_tuple = time.localtime() # get struct_time
-        time_string = time.strftime("%m-%d-%Y, %H:%M:%S", named_tuple)
+        time_string = time.strftime("%m-%d-%Y %H-%M-%S", named_tuple)
 
         self.TracemallocFile = '/' + time_string + ' ' + fileName
 
         file = open(self.TracemallocPath + self.TracemallocFile,"x")
         file.close()
+
+    def StartChecker(self):
+        tracemalloc.start()
     
-    def SaveSnapshot(self, key, snapshot):
-        self.Snapshot[key] = snapshot
+    def SaveSnapshot(self, key):
+        self.Snapshot[key] = tracemalloc.take_snapshot()
         self.Top_stats = self.Snapshot[key].statistics('lineno')
 
-    def WriteToFile(self, key, traced_memory):
+    def WriteToFile(self, key):
         file = open(self.TracemallocPath + self.TracemallocFile, 'a')
         file.write(f"[Writing tracemalloc for {key}]\n")
 
@@ -38,7 +54,7 @@ class CheckMemoryLeak():
             file.writelines(text)
             file.write('\n')
 
-        file.write('\nTraced memory is (current, peak):' + str(traced_memory) + '\n\n')
+        file.write('\nTraced memory is (current, peak):' + str(tracemalloc.get_traced_memory()) + '\n\n')
         file.close()
 
     def CompareSnapshots(self):

--- a/JANGAN/GlobalConfig.ini
+++ b/JANGAN/GlobalConfig.ini
@@ -1,8 +1,0 @@
-[TRACEMALLOC]
-
-# Check whether to run tracemalloc
-RunTraceMalloc = False
-
-# Directories for tracemalloc files
-TraceMallocDir = "../../Data/TraceMalloc"
-TraceMallocFile = "tracemalloc.txt"

--- a/JANGAN/JANGAN.pyproj
+++ b/JANGAN/JANGAN.pyproj
@@ -33,6 +33,7 @@
     <Compile Include="CGAN\__init__.py">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="CheckMemoryLeak\__init__.py" />
     <Compile Include="DataGenerator\DataExtractor.py" />
     <Compile Include="DataGenerator\FileImporter.py" />
     <Compile Include="DataGenerator\SharedFunctions.py" />
@@ -71,6 +72,7 @@
     <Folder Include="CGAN\" />
     <Folder Include="DataGenerator\" />
     <Folder Include="ExperimentQueue\" />
+    <Folder Include="CheckMemoryLeak\" />
     <Folder Include="ProjectTools\" />
     <Folder Include="ProjectTools\TestFiles\" />
   </ItemGroup>

--- a/JANGAN/JANGANQueue.py
+++ b/JANGAN/JANGANQueue.py
@@ -1,5 +1,4 @@
 import traceback
-import tracemalloc
 from ProjectTools import ConfigHelper    
 import JANGANQueueChecker
 import JANGANModuleReloader
@@ -18,23 +17,7 @@ print(" --- Done! --- ")
 print("")
 
 expDict = cfg.GetListValue("EXPERIMENTS","ExperimentList")
-
-gCfg = ConfigHelper.ConfigHelper("GlobalConfig.ini")
-gCfg.LoadConfig()
-
-runTraceMalloc = gCfg.GetBoolValue("TRACEMALLOC", "RunTraceMalloc")
-
-if (runTraceMalloc):
-    print(" --- Starting Trace Malloc ---")
-    tracemalloc.start()
-
-    checkMemoryLeak = cml.CheckMemoryLeak()
-    checkMemoryLeak.ConfigurePath(gCfg.GetStringValue("TRACEMALLOC", "TraceMallocDir"), gCfg.GetStringValue("TRACEMALLOC", "TraceMallocFile"))
-
 for key in expDict:
-    if (runTraceMalloc):
-        checkMemoryLeak.SaveKey(key)
-
     count = cfg.GetIntValue(key,'AmountOfTimesToRun')
     for n in range(count):
         print("")
@@ -62,19 +45,10 @@ for key in expDict:
 
         JANGANModuleReloader.JANGANModuleReloader().ReloadModules()
 
-        if (runTraceMalloc): 
-            checkMemoryLeak.SaveSnapshot(key, tracemalloc.take_snapshot())
-        
         print("")
         print(f" --- Experiment iteration '{n + 1}' done! --- ")
         print("")
-       
-    if (runTraceMalloc): 
-        checkMemoryLeak.WriteToFile(key, tracemalloc.get_traced_memory())
 
     print("")
     print(f" --- Experiment '{key}' done! --- ")
     print("")
-
-if (runTraceMalloc): 
-    checkMemoryLeak.CompareSnapshots()


### PR DESCRIPTION
Its not good that said class was a part of the production code, and also it simply did not work on windows.

* Actually made the MemoryChecker work on windows
* Removed all referenced to the memory checker in the production code
* Removed "Global" config file
* Added some comments, telling how to use the class in the future